### PR TITLE
Prevent horizontal overflow on small screens

### DIFF
--- a/stylesheets/main.scss
+++ b/stylesheets/main.scss
@@ -15,6 +15,7 @@ body {
 
 .Splash-inner {
   position: absolute;
+  box-sizing: border-box;
   width: 100%;
   top: 50%;
   padding: 20px;


### PR DESCRIPTION
Before:

<img width="405" alt="Skärmavbild 2022-03-10 kl  20 59 01" src="https://user-images.githubusercontent.com/66666/157744827-c13c1a79-7b43-4431-b336-3e344be5e00a.png">

After:

<img width="395" alt="Skärmavbild 2022-03-10 kl  20 59 08" src="https://user-images.githubusercontent.com/66666/157744834-98fb1e4f-9fed-4662-b9ca-8e6e9e9cb4f7.png">

